### PR TITLE
1.19 1.19.2 - A GUI Mining Support For AutoSwitch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version = 5.4.7
+mod_version = 5.4.8-alpha.1
 maven_group = dex.autoswitch
 archives_base_name = autoswitch
 

--- a/src/main/java/autoswitch/mixin/mixins/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/autoswitch/mixin/mixins/MixinClientPlayerInteractionManager.java
@@ -44,10 +44,10 @@ public abstract class MixinClientPlayerInteractionManager {
         assert this.client.player != null;
         assert this.client.crosshairTarget != null;
         if (this.client.crosshairTarget.equals(this.prevTarget)) return;
-        if (this.client.options.attackKey.isPressed() || this.client.options.attackKey.wasPressed()) {
+        if (this.client.options.attackKey.isPressed()) {
             SwitchEventTriggerImpl.attack(0, this.client.player, this.client.crosshairTarget);
             this.prevTarget = this.client.crosshairTarget;
-        } else if (this.client.options.useKey.isPressed() || this.client.options.useKey.wasPressed()) {
+        } else if (this.client.options.useKey.isPressed()) {
             SwitchEventTriggerImpl.interact(this.breakingBlock, this.client.player,
                                             this.client.crosshairTarget);
             this.prevTarget = this.client.crosshairTarget;

--- a/src/main/java/autoswitch/selectors/futures/IdentifiedTag.java
+++ b/src/main/java/autoswitch/selectors/futures/IdentifiedTag.java
@@ -40,7 +40,7 @@ public record IdentifiedTag<T>(TagKey<T> tagKey, Class<T> clazz, RegistryType ty
     @SuppressWarnings("unchecked")
     public static <U> IdentifiedTag<U> getOrCreate(TagKey<U> tagKey, Class<U> clazz, RegistryType type,
                                                    Predicate<Object> defaultIsIn) {
-        return (IdentifiedTag<U>) IDENTIFIED_TAGS.computeIfAbsent(tagKey, t -> new IdentifiedTag<>(tagKey, clazz, type, defaultIsIn));
+        return (IdentifiedTag<U>) IDENTIFIED_TAGS.computeIfAbsent(tagKey, $ -> new IdentifiedTag<>(tagKey, clazz, type, defaultIsIn));
     }
 
     public static IdentifiedTag<Item> getOrCreateItem(TagKey<Item> tagKey) {
@@ -135,6 +135,16 @@ public record IdentifiedTag<T>(TagKey<T> tagKey, Class<T> clazz, RegistryType ty
         buildFutureEntries();
         FALLBACK_ENTRIES.get(this).trim();
         return FALLBACK_ENTRIES.get(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IdentifiedTag<?> r) {
+            // Lambdas aren't equal to each other, and we only really only care about tag anyways
+            return r.tagKey.equals(tagKey) && r.type().equals(type);
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
To talk about what I mean by this request is that, it would be cool and nice to have optional choices on what to mine. So for example, Let's say, I look at a block and make a button that tells the client to take that block and mine it with whatever like a tool of a pickaxe. Because there's some server that dealt with some mining problems. Where a block is being mined with an axe instead of a pickaxe. So I'm asking for an easier way to make it so proper tools are being used.

- Gui of optional choices for looking at the block and copying that nbt block. And two add/remove options for certain blocks in servers or own worlds.
- Categories of servers/own worlds are separating different blocks and nbt blocks.
- Smooth Gui and or customize our own Gui with buttons, and being able to toggle between different settings of its options.