### PR TITLE
Fix depleted check so 1-durability tools can be selected

### DIFF
--- a/fabric/src/main/java/dex/autoswitch/Autoswitch.java
+++ b/fabric/src/main/java/dex/autoswitch/Autoswitch.java
@@ -81,7 +81,7 @@ public class Autoswitch implements ClientModInitializer {
                 ((Collection<Predicate<ItemStack>>)collection).add(stack -> {
 
                     if (stack.isDamageableItem()) {
-                        return stack.nextDamageWillBreak();
+                        return stack.getDamageValue() >= stack.getMaxDamage();
                     }
 
                     return false;

--- a/neoforge/src/main/java/dex/autoswitch/Autoswitch.java
+++ b/neoforge/src/main/java/dex/autoswitch/Autoswitch.java
@@ -66,7 +66,7 @@ public class Autoswitch {
         InterModComms.sendTo(Constants.MOD_ID, AutoSwitchApi.INSTANCE.DEPLETED.id().getPath(),
                 () -> (Predicate<ItemStack>) stack -> {
                     if (stack.isDamageableItem()) {
-                        return stack.nextDamageWillBreak();
+                        return stack.getDamageValue >= stack.getMaxDamage();
                     }
 
                     return false;


### PR DESCRIPTION
Bug: tools at 1 durability were treated as depleted because nextDamageWillBreak() returns true.

Fix: consider depleted only when damage >= maxDamage so 1 durability tools can still be selected.

Changed in both Fabric + NeoForge entrypoints.